### PR TITLE
chore: ignore unnecessary files in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.git
+src/**/*.test.*
+.next
+dist
+build
+out


### PR DESCRIPTION
## Summary
- prevent node modules, git data, tests and build outputs from entering Docker context

## Testing
- `npm run lint`
- `docker build --no-cache .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68965ea89eb4832eaa553ab0794e5dda